### PR TITLE
Add daily-build failure notification

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,24 +17,6 @@ jobs:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2
 
-            # Set up Java Environment
-            - name: Set up JDK 11
-              uses: actions/setup-java@v1
-              with:
-                java-version: 11
-            
-            # Grant execute permission to the gradlew script
-            - name: Grant execute permission for gradlew
-              run: chmod +x gradlew
-
-            # Build the project with Gradle
-            - name: Build with Gradle
-              env:
-                packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
-              run: |
-                ./gradlew build
             # Build the ballerina project
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@nightly
@@ -42,18 +24,22 @@ jobs:
                   args:
                       build -c ./ses
               env:
-                JAVA_HOME: /usr/lib/jvm/default-jvm
                 ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
                 SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
                 SENDER_EMAIL: ${{ secrets.SENDER_EMAIL }}
                 RECEIVER_EMAIL: ${{ secrets.RECEIVER_EMAIL }}
                 EMAIL_IDENTITY: ${{ secrets.EMAIL_IDENTITY }}
-            # Publish Github Package
-            - name: Publish Github Package
-              env:
-                publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-                publishPAT: ${{ secrets.CONNECTOR_PUBLISH_PAT }}
-                JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
+
+            # Send notification when build fails
+            - name: Notify failure
+              if: ${{ failure() }}
               run: |
-                ./gradlew publish
+                curl \
+                -X POST 'https://chat.googleapis.com/v1/spaces/${{secrets.BALLERINA_CHAT_ID}}/messages?key=${{secrets.BALLERINA_CHAT_KEY}}&token=${{secrets.BALLERINA_CHAT_TOKEN}}' \
+                --header 'Content-Type: application/json' \
+                -d '{"text": "*module-ballerinax-aws.ses* daily build failure \nPlease visit <https://github.com/ballerina-platform/module-ballerinax-aws.ses/actions/workflows/daily-build.yml|the daily build page> for more information"}'
+                curl \
+                -X POST 'https://chat.googleapis.com/v1/spaces/${{secrets.CONNECTOR_CHAT_ID}}/messages?key=${{secrets.CONNECTOR_CHAT_KEY}}&token=${{secrets.CONNECTOR_CHAT_TOKEN}}' \
+                --header 'Content-Type: application/json' \
+                -d '{"text": "*module-ballerinax-aws.ses* daily build failure \nPlease visit <https://github.com/ballerina-platform/module-ballerinax-aws.ses/actions/workflows/daily-build.yml|the daily build page> for more information"}'
                 


### PR DESCRIPTION
## Purpose
- Add failure notification for daily build
- Remove gradle related steps as they are not necessary in daily build workflow

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3