### PR TITLE
Fix CURL command in daily build fail notification

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -35,10 +35,10 @@ jobs:
             - name: Notify failure
               if: ${{ failure() }}
               run: |
-                curl -X POST
-                'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches'\
-                -H 'Accept: application/vnd.github.v3+json'\
-                -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}'\
+                curl -X POST \
+                'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches' \
+                -H 'Accept: application/vnd.github.v3+json' \
+                -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
                 --data "{
                   \"event_type\": \"notify-connector-failure\",
                   \"client_payload\": {


### PR DESCRIPTION
# Description
Fix syntax issue in CURL command used in daily build failure notification.

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 