### PR TITLE
Fix warning messages

### DIFF
--- a/ses/tests/test.bal
+++ b/ses/tests/test.bal
@@ -86,7 +86,7 @@ function testGetContactList() returns error? {
 }
 function testListContactLists() returns error? {
     log:printInfo("Testing ListContactLists");
-    ContactLists response =  check amazonSesClient->listContactLists();
+    _ =  check amazonSesClient->listContactLists();
 }
 
 @test:Config {
@@ -136,7 +136,7 @@ function testGetContact() returns error? {
 }
 function testListContacts() returns error? {
     log:printInfo("Testing ListContacts");
-    Contacts  response = check amazonSesClient-> listContacts(contactListName);
+    _ = check amazonSesClient-> listContacts(contactListName);
 }
 
 @test:Config {
@@ -192,7 +192,7 @@ function testUpdateCustomVeriﬁcationEmailTemplate() returns error? {
 
 function testListCustomVeriﬁcationEmailTemplates() returns error? {
     log:printInfo("Testing ListCustomVeriﬁcationEmailTemplates");
-    CustomVerificationTempListPage response = check amazonSesClient->listCustomVeriﬁcationEmailTemplates();
+    _ = check amazonSesClient->listCustomVeriﬁcationEmailTemplates();
 }
 
 @test:Config {
@@ -246,7 +246,7 @@ function testUpdateEmailTemplate() returns error? {
 
 function testListEmailTemplates() returns error? {
     log:printInfo("Testing ListEmailTemplates");
-    EmailTemplateListPage response = check amazonSesClient->listEmailTemplates();
+    _ = check amazonSesClient->listEmailTemplates();
 }
 
 @test:Config {}
@@ -264,7 +264,7 @@ function testCreateEmailIdentity() returns error? {
 }
 function testGetEmailIdentity() returns error? {
     log:printInfo("Testing GetEmailIdentity");
-    EmailIdentityInfo response = check amazonSesClient->getEmailIdentity(emailIdentity);
+    _ = check amazonSesClient->getEmailIdentity(emailIdentity);
 }
 
 @test:Config {
@@ -272,7 +272,7 @@ function testGetEmailIdentity() returns error? {
 }
 function testListEmailIdentities() returns error? {
     log:printInfo("Testing ListEmailIdentities");
-    EmailIdentitiesListPage response = check amazonSesClient->listEmailIdentities();
+    _ = check amazonSesClient->listEmailIdentities();
 }
 
 @test:Config {


### PR DESCRIPTION
# Description
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/205

# Purpose
- Fix following warning messages
```
Compiling source
	ballerinax/aws.ses:1.0.0
WARNING [tests/test.bal:(89:5,89:72)] unused variable 'response'
WARNING [tests/test.bal:(139:5,139:80)] unused variable 'response'
WARNING [tests/test.bal:(195:5,195:108)] unused variable 'response'
WARNING [tests/test.bal:(249:5,249:82)] unused variable 'response'
WARNING [tests/test.bal:(267:5,267:89)] unused variable 'response'
WARNING [tests/test.bal:(275:5,275:85)] unused variable 'response'
```

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
