### PR TITLE
Fix type missmatch  error

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -342,9 +342,9 @@ function testSendBulkEmail() {
             }
         }
     };
-    MessageSentResponse|error response =  amazonSesClient->sendBulkEmail(req);
-    if response is MessageSentResponse {
-        log:printInfo(response?.MessageId.toString());
+    BulkEmailResponse|error response =  amazonSesClient->sendBulkEmail(req);
+    if response is BulkEmailResponse {
+        log:printInfo(response?.BulkEmailEntryResults.toString());
     }
 }
 


### PR DESCRIPTION
# Description

Fix Type Missmatch Error for U8 : [incompatible types: expected '(ballerinax/aws.ses:2.0.0:MessageSentResponse|error)', found '(ballerinax/aws.ses:2.0.0:BulkEmailResponse|error)']


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

